### PR TITLE
Trim data line in case of spaces

### DIFF
--- a/src/Tag/ExtInf.php
+++ b/src/Tag/ExtInf.php
@@ -79,6 +79,7 @@ example:
 #EXTINF:-1 tvg-name=Первый_HD tvg-logo="Первый канал" deinterlace=4 group-title="Эфирные каналы",Первый канал HD
          */
         $dataLineStr = \substr($lineStr, \strlen('#EXTINF:'));
+        $dataLineStr = \trim($dataLineStr);
 
         // Parse duration and title with regex
         \preg_match('/^(-?\d+)\s*(?:(?:[^=]+=["\'][^"\']*["\'])|(?:[^=]+=[^ ]*))*,(.*)$/', $dataLineStr, $matches);

--- a/tests/Tag/ExtInfTest.php
+++ b/tests/Tag/ExtInfTest.php
@@ -22,7 +22,7 @@ class ExtInfTest extends TestCase
         $m3uParser->addDefaultTags();
         $data = $m3uParser->parseFile(__DIR__.'/../fixtures/extinf.m3u');
 
-        self::assertCount(4, $data);
+        self::assertCount(5, $data);
 
         self::assertContainsOnlyInstancesOf(M3uParserEntry::class, $data);
 

--- a/tests/fixtures/extinf.m3u
+++ b/tests/fixtures/extinf.m3u
@@ -10,3 +10,6 @@ http://109.225.233.1:30000/udp/239.255.10.160:5500
 
 #EXTINF:-1 tvg-name="Test with, comma 1/2" tvg-logo="https://pngimage.net/wp-content/uploads/2018/05/iptv-png.png" group-title="===test group title 1/2",Test with, comma 1/2
 http://117.210.233.1:3000/tcp/2
+
+#EXTINF: -1 tvg-name="Test with space" tvg-logo="https://pngimage.net/wp-content/uploads/2018/05/iptv-png.png" group-title="===test group title 1/2",Test with, comma 1/2
+http://117.210.233.1:3000/tcp/2


### PR DESCRIPTION
Hey,

in my case an external generated m3u file had a space at the beginning of the data line.
This caused an error in your lib. A simple trim fixes this issue.

Greetings